### PR TITLE
Version 0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,5 @@ jobs:
             tag: ${{ env.version_name }}
             name: Release ${{ env.version_name }}
             generateReleaseNotes: true
-            draft: true
+            draft: false
             prerelease: false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "nl.mmathijs"
-version = "0.1.0"
+version = "0.1.1"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/nl/mmathijs/rabidrider/geometry/Line2d.kt
+++ b/src/main/kotlin/nl/mmathijs/rabidrider/geometry/Line2d.kt
@@ -15,10 +15,10 @@ class Line2d(@JvmField val point1: Vector2d, @JvmField val point2: Vector2d) {
 
 
     fun intersects(other: Line2d, includeEnd: Boolean = true): Boolean {
-        return getIntersection(other, includeEnd) != null
+        return intersection(other, includeEnd) != null
     }
 
-    fun getIntersection(other: Line2d, includeEnd: Boolean = true): Vector2d? {
+    fun intersection(other: Line2d, includeEnd: Boolean = true): Vector2d? {
         val denominator =
             (other.point2.y - other.point1.y) * (point2.x - point1.x) - (other.point2.x - other.point1.x) * (point2.y - point1.y)
         val numerator1 =

--- a/src/main/kotlin/nl/mmathijs/rabidrider/geometry/Line2d.kt
+++ b/src/main/kotlin/nl/mmathijs/rabidrider/geometry/Line2d.kt
@@ -15,6 +15,10 @@ class Line2d(@JvmField val point1: Vector2d, @JvmField val point2: Vector2d) {
 
 
     fun intersects(other: Line2d, includeEnd: Boolean = true): Boolean {
+        return getIntersection(other, includeEnd) != null
+    }
+
+    fun getIntersection(other: Line2d, includeEnd: Boolean = true): Vector2d? {
         val denominator =
             (other.point2.y - other.point1.y) * (point2.x - point1.x) - (other.point2.x - other.point1.x) * (point2.y - point1.y)
         val numerator1 =
@@ -23,16 +27,28 @@ class Line2d(@JvmField val point1: Vector2d, @JvmField val point2: Vector2d) {
             (point2.x - point1.x) * (point1.y - other.point1.y) - (point2.y - point1.y) * (point1.x - other.point1.x)
 
         if (denominator == 0.0) {
-            return numerator1 == 0.0 && numerator2 == 0.0
+            return if (numerator1 == 0.0 && numerator2 == 0.0) {
+                point1
+            } else {
+                null
+            }
         }
 
         val r = numerator1 / denominator
         val s = numerator2 / denominator
 
         return if (includeEnd) {
-            r in 0.0..1.0 && s in 0.0..1.0
+            if (r in 0.0..1.0 && s in 0.0..1.0) {
+                point1 + (point2 - point1) * r
+            } else {
+                null
+            }
         } else {
-            r > 0.0 && r < 1.0 && s > 0.0 && s < 1.0
+            if (r > 0.0 && r < 1.0 && s > 0.0 && s < 1.0) {
+                point1 + (point2 - point1) * r
+            } else {
+                null
+            }
         }
     }
 }

--- a/src/main/kotlin/nl/mmathijs/rabidrider/geometry/Rectangle2d.kt
+++ b/src/main/kotlin/nl/mmathijs/rabidrider/geometry/Rectangle2d.kt
@@ -84,7 +84,7 @@ class Rectangle2d(@JvmField val point1: Vector2d, @JvmField val point2: Vector2d
 
     fun intersections(line: Line2d): List<Vector2d> {
         // It is possible that a line intersects multiple lines, at the intersection of 2 lines, so we use distinct to remove duplicates
-        return getLines().mapNotNull { it.getIntersection(line) }.distinct()
+        return getLines().mapNotNull { it.intersection(line) }.distinct()
     }
 
     fun distanceIntersection(line: Line2d, point: Vector2d? = null): Double {

--- a/src/main/kotlin/nl/mmathijs/rabidrider/geometry/Rectangle2d.kt
+++ b/src/main/kotlin/nl/mmathijs/rabidrider/geometry/Rectangle2d.kt
@@ -81,5 +81,16 @@ class Rectangle2d(@JvmField val point1: Vector2d, @JvmField val point2: Vector2d
     fun contains(line: Line2d): Boolean {
         return contains(line.point1) && contains(line.point2)
     }
+
+    fun intersections(line: Line2d): List<Vector2d> {
+        // It is possible that a line intersects multiple lines, at the intersection of 2 lines, so we use distinct to remove duplicates
+        return getLines().mapNotNull { it.getIntersection(line) }.distinct()
+    }
+
+    fun distanceIntersection(line: Line2d, point: Vector2d? = null): Double {
+        return intersections(line).minOfOrNull {
+            it.distTo(point ?: line.point1)
+        } ?: Double.POSITIVE_INFINITY
+    }
 }
 

--- a/src/test/kotlin/nl/mmathijs/rabidrider/geometry/Line2dTest.kt
+++ b/src/test/kotlin/nl/mmathijs/rabidrider/geometry/Line2dTest.kt
@@ -7,6 +7,7 @@ import kotlin.math.PI
 import kotlin.math.sqrt
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class Line2dTest {
@@ -25,7 +26,7 @@ class Line2dTest {
     }
 
     @Test
-    fun testLineIntersect() {
+    fun lineIntersectTest() {
         val line1 = Line2d(Vector2d(0.0, 0.0), Vector2d(1.0, 1.0))
         val line2 = Line2d(Vector2d(0.0, 1.0), Vector2d(1.0, 0.0))
 
@@ -41,5 +42,22 @@ class Line2dTest {
 
         assertFalse(line1.intersects(line4))
         assertFalse(line1.intersects(line4, false))
+    }
+
+    @Test
+    fun lineIntersectionsTest() {
+        val line1 = Line2d(Vector2d(0.0, 0.0), Vector2d(1.0, 1.0))
+        val line2 = Line2d(Vector2d(0.0, 1.0), Vector2d(1.0, 0.0))
+
+        assertEquals(Vector2d(0.5, 0.5), line1.getIntersection(line2))
+
+        val line3 = Line2d(Vector2d(0.0, 0.0), Vector2d(1.0, 0.0))
+
+        assertEquals(Vector2d(0.0, 0.0), line1.getIntersection(line3))
+        assertNull(line1.getIntersection(line3, false))
+
+        val line4 = Line2d(Vector2d(0.0, 1.0), Vector2d(1.0, 2.0))
+
+        assertNull(line1.getIntersection(line4))
     }
 }

--- a/src/test/kotlin/nl/mmathijs/rabidrider/geometry/Line2dTest.kt
+++ b/src/test/kotlin/nl/mmathijs/rabidrider/geometry/Line2dTest.kt
@@ -49,15 +49,15 @@ class Line2dTest {
         val line1 = Line2d(Vector2d(0.0, 0.0), Vector2d(1.0, 1.0))
         val line2 = Line2d(Vector2d(0.0, 1.0), Vector2d(1.0, 0.0))
 
-        assertEquals(Vector2d(0.5, 0.5), line1.getIntersection(line2))
+        assertEquals(Vector2d(0.5, 0.5), line1.intersection(line2))
 
         val line3 = Line2d(Vector2d(0.0, 0.0), Vector2d(1.0, 0.0))
 
-        assertEquals(Vector2d(0.0, 0.0), line1.getIntersection(line3))
-        assertNull(line1.getIntersection(line3, false))
+        assertEquals(Vector2d(0.0, 0.0), line1.intersection(line3))
+        assertNull(line1.intersection(line3, false))
 
         val line4 = Line2d(Vector2d(0.0, 1.0), Vector2d(1.0, 2.0))
 
-        assertNull(line1.getIntersection(line4))
+        assertNull(line1.intersection(line4))
     }
 }

--- a/src/test/kotlin/nl/mmathijs/rabidrider/geometry/Rectangle2dTest.kt
+++ b/src/test/kotlin/nl/mmathijs/rabidrider/geometry/Rectangle2dTest.kt
@@ -1,9 +1,8 @@
 package nl.mmathijs.rabidrider.geometry
 
 import com.acmerobotics.roadrunner.geometry.Vector2d
-import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.math.sqrt
+import kotlin.test.*
 
 class Rectangle2dTest {
 
@@ -35,5 +34,94 @@ class Rectangle2dTest {
 
         assertTrue(rectangle.intersects(Line2d(Vector2d(-1.0, -1.0), Vector2d(2.0, 2.0))))
         assertTrue(rectangle.intersects(Line2d(Vector2d(0.5, 0.5), Vector2d(1.5, 1.5))))
+    }
+
+    @Test
+    fun distanceToIntersectionTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(1.0, 1.0))
+
+        assertEquals(
+            sqrt(2.0), rectangle.distanceIntersection(
+                Line2d(Vector2d(-1.0, -1.0), Vector2d(2.0, 2.0))
+            )
+        )
+
+        assertEquals(
+            sqrt(0.5), rectangle.distanceIntersection(
+                Line2d(Vector2d(0.5, 0.5), Vector2d(1.5, 1.5))
+            )
+        )
+
+        assertEquals(
+            Double.POSITIVE_INFINITY, rectangle.distanceIntersection(
+                Line2d(Vector2d(0.5, 0.5), Vector2d(0.6, 0.6))
+            )
+        )
+
+        assertEquals(
+            0.5, rectangle.distanceIntersection(
+                Line2d(Vector2d(-1.0, 0.5), Vector2d(2.0, 0.5)),
+                Vector2d(-0.5, 0.5)
+            )
+        )
+
+        assertEquals(
+            0.5, rectangle.distanceIntersection(
+                Line2d(Vector2d(0.5, -1.0), Vector2d(0.5, 2.0)),
+                Vector2d(0.5, -0.5)
+            )
+        )
+    }
+
+    @Test
+    fun intersectionsTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(1.0, 1.0))
+
+        assertTrue(
+            listEqualsWithoutOrder(
+                listOf(Vector2d(0.0, 0.0), Vector2d(1.0, 1.0)),
+                rectangle.intersections(Line2d(Vector2d(-1.0, -1.0), Vector2d(2.0, 2.0)))
+            )
+        )
+
+        assertTrue(
+            listEqualsWithoutOrder(
+                listOf(Vector2d(1.0, 1.0)),
+                rectangle.intersections(Line2d(Vector2d(0.5, 0.5), Vector2d(1.5, 1.5)))
+            )
+        )
+
+        assertEquals(
+            listOf<Vector2d>(),
+            rectangle.intersections(Line2d(Vector2d(2.0, 2.0), Vector2d(3.0, 3.0)))
+        )
+
+        assertEquals(
+            listOf<Vector2d>(),
+            rectangle.intersections(Line2d(Vector2d(-1.0, -1.0), Vector2d(-2.0, -2.0)))
+        )
+
+        assertEquals(
+            listOf<Vector2d>(),
+            rectangle.intersections(Line2d(Vector2d(0.5, 0.5), Vector2d(0.6, 0.6)))
+        )
+
+        assertTrue(
+            listEqualsWithoutOrder(
+                listOf<Vector2d>(Vector2d(0.0, 0.5), Vector2d(1.0, 0.5)),
+                rectangle.intersections(Line2d(Vector2d(-1.0, 0.5), Vector2d(2.0, 0.5)))
+            )
+        )
+
+        assertTrue(
+            listEqualsWithoutOrder(
+                listOf<Vector2d>(Vector2d(0.5, 0.0), Vector2d(0.5, 1.0)),
+                rectangle.intersections(Line2d(Vector2d(0.5, -1.0), Vector2d(0.5, 2.0)))
+            )
+        )
+    }
+
+    private fun listEqualsWithoutOrder(first: List<Vector2d>, second: List<Vector2d>): Boolean {
+        return first.containsAll(second) && second.containsAll(first) && first.size == second.size
     }
 }


### PR DESCRIPTION
# Changelog:
## New:
### Line2d:
- `intersection(other: Line2d, includeEnd: Boolean = true): Vector2d?` Get the Vector2d of the intersection between two lines, null if there is none
### Rectangle2d:
- `intersections(line: Line2d): List<Vector2d>` Get all intersections of the line and the border of the rectangle
- `distanceIntersection(line: Line2d, point: Vector2d? = null)` Double: Get the distance to the closest intersection of a line with the border of the rectangle from the first point of the line OR from point if point is defined

## Changed:
### Line2d:
- `intersects(other: Line2d, includeEnd: Boolean = true): Boolean` Now uses `intersections(line: Line2d)`, no functional change
### Version:
- Bump version to 0.1.1
### Workflow
- Made release final instead of draft

## Tests:
### Line2d:
- New tests for: `intersection(other: Line2d, includeEnd: Boolean = true): Vector2d?` 
- Renamed 'testLineIntersect' to `lineIntersectTest` for consistentcy
### Rectangle2d:
- New tests for: `intersectionsTest` and `distanceToIntersectionsTest`