### PR TITLE
Added more tests for Rectangle2d and Line2d

### DIFF
--- a/src/test/kotlin/nl/mmathijs/rabidrider/geometry/Line2dTest.kt
+++ b/src/test/kotlin/nl/mmathijs/rabidrider/geometry/Line2dTest.kt
@@ -58,5 +58,9 @@ class Line2dTest {
         val line4 = Line2d(Vector2d(0.0, 1.0), Vector2d(1.0, 2.0))
 
         assertNull(line1.intersection(line4))
+
+        val line5 = Line2d(Vector2d(0.0, 0.0), Vector2d(1.0, 1.0))
+
+        assertEquals(Vector2d(0.0, 0.0), line1.intersection(line5))
     }
 }

--- a/src/test/kotlin/nl/mmathijs/rabidrider/geometry/Rectangle2dTest.kt
+++ b/src/test/kotlin/nl/mmathijs/rabidrider/geometry/Rectangle2dTest.kt
@@ -5,6 +5,27 @@ import kotlin.math.sqrt
 import kotlin.test.*
 
 class Rectangle2dTest {
+    private fun listEqualsWithoutOrder(first: List<Any>, second: List<Any>): Boolean {
+        return first.containsAll(second) && second.containsAll(first) && first.size == second.size
+    }
+
+    private fun rectangleEquals(rectangle1: Rectangle2d, rectangle2: Rectangle2d): Boolean =
+        (rectangle1.point1 == rectangle2.point1 && rectangle1.point2 == rectangle2.point2) ||
+                (rectangle1.point1 == rectangle2.point2 && rectangle1.point2 == rectangle2.point1)
+
+    private fun line2dListEqualsWithoutOrder(first: List<Line2d>, second: List<Line2d>): Boolean {
+        return first.stream().allMatch { line1 ->
+            second.stream().anyMatch { line2 ->
+                line1.point1 == line2.point1 && line1.point2 == line2.point2 ||
+                        line1.point1 == line2.point2 && line1.point2 == line2.point1
+            }
+        } && second.stream().allMatch { line1 ->
+            first.stream().anyMatch { line2 ->
+                line1.point1 == line2.point1 && line1.point2 == line2.point2 ||
+                        line1.point1 == line2.point2 && line1.point2 == line2.point1
+            }
+        } && first.size == second.size
+    }
 
     @Test
     fun containsPointTest() {
@@ -121,7 +142,250 @@ class Rectangle2dTest {
         )
     }
 
-    private fun listEqualsWithoutOrder(first: List<Vector2d>, second: List<Vector2d>): Boolean {
-        return first.containsAll(second) && second.containsAll(first) && first.size == second.size
+    @Test
+    fun growTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(1.0, 1.0))
+
+        assert(
+            rectangleEquals(
+                rectangle.grow(Vector2d(0.5, 0.5)),
+                Rectangle2d(Vector2d(-0.5, -0.5), Vector2d(1.5, 1.5))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.grow(0.5),
+                Rectangle2d(Vector2d(-0.5, -0.5), Vector2d(1.5, 1.5))
+            )
+        )
+    }
+
+    @Test
+    fun shrinkTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))
+
+        assert(
+            rectangleEquals(
+                rectangle.shrink(Vector2d(0.5, 0.5)),
+                Rectangle2d(Vector2d(0.5, 0.5), Vector2d(1.5, 1.5))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.shrink(0.5),
+                Rectangle2d(Vector2d(0.5, 0.5), Vector2d(1.5, 1.5))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.shrink(Vector2d(1.0, 1.0)),
+                Rectangle2d(Vector2d(1.0, 1.0), Vector2d(1.0, 1.0))
+            )
+        )
+    }
+
+    @Test
+    fun scaleFromOriginTest() {
+        val rectangle = Rectangle2d(Vector2d(2.0, 2.0), Vector2d(4.0, 4.0))
+
+        assert(
+            rectangleEquals(
+                rectangle.scaleFromOrigin(Vector2d(2.0, 2.0)),
+                Rectangle2d(Vector2d(4.0, 4.0), Vector2d(8.0, 8.0))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.scaleFromOrigin(2.0),
+                Rectangle2d(Vector2d(4.0, 4.0), Vector2d(8.0, 8.0))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.scaleFromOrigin(Vector2d(0.5, 0.5)),
+                Rectangle2d(Vector2d(1.0, 1.0), Vector2d(2.0, 2.0))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.scaleFromOrigin(0.5),
+                Rectangle2d(Vector2d(1.0, 1.0), Vector2d(2.0, 2.0))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.scaleFromOrigin(Vector2d(0.5, 2.0)),
+                Rectangle2d(Vector2d(1.0, 4.0), Vector2d(2.0, 8.0))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.scaleFromOrigin(Vector2d(2.0, 0.5)),
+                Rectangle2d(Vector2d(4.0, 1.0), Vector2d(8.0, 2.0))
+            )
+        )
+    }
+
+    @Test
+    fun scaleFromCenterTest() {
+        val rectangle = Rectangle2d(Vector2d(2.0, 2.0), Vector2d(4.0, 4.0))
+
+        assert(
+            rectangleEquals(
+                rectangle.scaleFromCenter(Vector2d(2.0, 2.0)),
+                Rectangle2d(Vector2d(1.0, 1.0), Vector2d(5.0, 5.0))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.scaleFromCenter(0.5),
+                Rectangle2d(Vector2d(2.5, 2.5), Vector2d(3.5, 3.5))
+            )
+        )
+    }
+
+    @Test
+    fun containsLineTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))
+
+        assertTrue(rectangle.contains(Line2d(Vector2d(0.5, 0.5), Vector2d(1.5, 1.5))))
+        assertTrue(rectangle.contains(Line2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))))
+
+        assertFalse(rectangle.contains(Line2d(Vector2d(0.5, 0.5), Vector2d(2.5, 1.5))))
+        assertFalse(rectangle.contains(Line2d(Vector2d(-0.5, -0.5), Vector2d(1.5, 1.5))))
+    }
+
+    @Test
+    fun containsVectorTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))
+
+        assertTrue(rectangle.contains(Vector2d(0.5, 0.5)))
+        assertTrue(rectangle.contains(Vector2d(0.0, 0.0)))
+        assertTrue(rectangle.contains(Vector2d(2.0, 2.0)))
+
+        assertFalse(rectangle.contains(Vector2d(0.5, 2.5)))
+        assertFalse(rectangle.contains(Vector2d(-0.5, -0.5)))
+
+        val rectangle2 = Rectangle2d(Vector2d(2.0, 2.0), Vector2d(0.0, 0.0))
+
+        assertTrue(rectangle2.contains(Vector2d(0.5, 0.5)))
+        assertTrue(rectangle2.contains(Vector2d(0.0, 0.0)))
+        assertTrue(rectangle2.contains(Vector2d(2.0, 2.0)))
+
+        assertFalse(rectangle2.contains(Vector2d(0.5, 2.5)))
+        assertFalse(rectangle2.contains(Vector2d(-0.5, -0.5)))
+    }
+
+    @Test
+    fun getPointTests() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))
+
+        assertEquals(Vector2d(0.0, 0.0), rectangle.getPoint1())
+        assertEquals(Vector2d(2.0, 2.0), rectangle.getPoint2())
+    }
+
+    @Test
+    fun linesTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))
+
+        assertTrue(
+            line2dListEqualsWithoutOrder(
+                listOf(
+                    Line2d(Vector2d(0.0, 0.0), Vector2d(2.0, 0.0)),
+                    Line2d(Vector2d(2.0, 0.0), Vector2d(2.0, 2.0)),
+                    Line2d(Vector2d(2.0, 2.0), Vector2d(0.0, 2.0)),
+                    Line2d(Vector2d(0.0, 2.0), Vector2d(0.0, 0.0))
+                ),
+                rectangle.lines()
+            )
+        )
+    }
+
+    @Test
+    fun translateTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))
+
+        assert(
+            rectangleEquals(
+                rectangle.translate(Vector2d(1.0, 1.0)),
+                Rectangle2d(Vector2d(1.0, 1.0), Vector2d(3.0, 3.0))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.translate(1.0, 1.0),
+                Rectangle2d(Vector2d(1.0, 1.0), Vector2d(3.0, 3.0))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.translate(Vector2d(-1.0, -1.0)),
+                Rectangle2d(Vector2d(-1.0, -1.0), Vector2d(1.0, 1.0))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.translate(-1.0, -1.0),
+                Rectangle2d(Vector2d(-1.0, -1.0), Vector2d(1.0, 1.0))
+            )
+        )
+
+        assert(
+            rectangleEquals(
+                rectangle.translate(Vector2d(1.0, -1.0)),
+                Rectangle2d(Vector2d(1.0, -1.0), Vector2d(3.0, 1.0))
+            )
+        )
+    }
+
+    @Test
+    fun getCenterTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))
+
+        assertEquals(Vector2d(1.0, 1.0), rectangle.getCenter())
+
+        val rectangle2 = Rectangle2d(Vector2d(2.0, 2.0), Vector2d(0.0, 0.0))
+
+        assertEquals(Vector2d(1.0, 1.0), rectangle2.getCenter())
+    }
+
+    @Test
+    fun getPerimeterTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))
+
+        assertEquals(8.0, rectangle.getPerimeter())
+    }
+
+    @Test
+    fun surfaceAreaTest() {
+        val rectangle = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))
+
+        assertEquals(4.0, rectangle.getArea())
+    }
+
+    @Test
+    fun intersectsRectangleTest() {
+        val rectangle1 = Rectangle2d(Vector2d(0.0, 0.0), Vector2d(2.0, 2.0))
+        val rectangle2 = Rectangle2d(Vector2d(1.0, 1.0), Vector2d(3.0, 3.0))
+
+        assertTrue(rectangle1.intersects(rectangle2))
+        assertTrue(rectangle2.intersects(rectangle1))
+
+        val rectangle3 = Rectangle2d(Vector2d(3.0, 3.0), Vector2d(4.0, 4.0))
+
+        assertFalse(rectangle1.intersects(rectangle3))
+        assertFalse(rectangle3.intersects(rectangle1))
     }
 }


### PR DESCRIPTION
# Changelog:
## Tests:
### Line2d
- Added a extra check for 2 lines that are equal
### Rectangle2d
- Added extra checks for a higher coverage:
  - `Rectangle2d.grow(amount: Vector2d)`, `Rectangle2d.grow(amount: Double)`
  - `Rectangle2d.shrink(amount: Vector2d)`, `Rectangle2d.shrink(amount: Double)`
  - `Rectangle2d.scaleFromOrigin(scale: Vector2d)`, `Rectangle2d.scaleFromOrigin(scale: Double)`
  - `Rectangle2d.scaleFromCenter(scale: Vector2d)`, `Rectangle2d.scaleFromCenter(scale: Double)`
  - `Rectangle2d.contains(line: Line2d)`
  - `Rectangle2d.contains(point: Vector2d)`
  - `Rectangle2d.getPoint1()`, `Rectangle2d.getPoint2()`
  - `Rectangle2d.lines()`, `Rectangle2d.getLines()`
  - `Rectangle2d.translate(vector: Vector2d)`, `Rectangle2d.translate(x: Double, y: Double)`
  - `Rectangle2d.getCenter()`
  - `Rectangle2d.getArea()`
  - `Rectangle2d.getPerimiter()`
  - `Rectangle2d.intersects(other: Rectangle2d)`

